### PR TITLE
Add controller tests and fixtures

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -311,7 +311,7 @@ Devise.setup do |config|
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
   config.jwt do |jwt|
-    jwt.secret = Rails.application.credentials.devise[:jwt_secret_key] || 'your_jwt_secret'
+    jwt.secret = Rails.application.credentials.dig(:devise, :jwt_secret_key) || 'your_jwt_secret'
     jwt.dispatch_requests = [
       ['POST', %r{^/api/v1/auth/login$}]
     ]

--- a/test/controllers/api/v1/auth_controller_test.rb
+++ b/test/controllers/api/v1/auth_controller_test.rb
@@ -1,7 +1,21 @@
 require "test_helper"
 
 class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'login with valid credentials returns jwt token' do
+    user = users(:admin_user)
+    post '/api/v1/auth/login', params: { email: user.email, password: 'password' }
+
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert body['token'].present?, 'Token should be present'
+  end
+
+  test 'login with invalid credentials returns unauthorized' do
+    user = users(:admin_user)
+    post '/api/v1/auth/login', params: { email: user.email, password: 'wrong' }
+
+    assert_response :unauthorized
+    body = JSON.parse(@response.body)
+    assert_equal 'Invalid Email or Password', body['error']
+  end
 end

--- a/test/controllers/api/v1/products_controller_test.rb
+++ b/test/controllers/api/v1/products_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Api::V1::ProductsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin_user)
+    @product = products(:one)
+    sign_in @admin
+  end
+
+  test "should get index" do
+    get api_v1_products_url
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal @product.id, body["productos"].first["id"]
+  end
+
+  test "should create product" do
+    assert_difference("Product.count") do
+      post api_v1_products_url, params: {
+        product: {
+          name: "Phone",
+          price: 500,
+          stock: 10,
+          description: "Smart phone",
+          administrator_id: @admin.id,
+          category_id: categories(:one).id
+        }
+      }
+    end
+    assert_response :created
+  end
+
+  test "should get top revenue" do
+    get top_revenue_api_v1_products_url
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal @product.id, body.first["id"]
+    assert body.first["total_revenue"].to_f > 0
+  end
+end

--- a/test/controllers/api/v1/purchases_controller_test.rb
+++ b/test/controllers/api/v1/purchases_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Api::V1::PurchasesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:admin_user)
+    @purchase = purchases(:one)
+    sign_in @user
+  end
+
+  test "should get index" do
+    get api_v1_purchases_url
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal @purchase.id, body.first["id"]
+  end
+
+  test "should create purchase" do
+    assert_difference("Purchase.count") do
+      post api_v1_purchases_url, params: {
+        purchase: {
+          product_id: products(:one).id,
+          customer_id: users(:customer_user).id,
+          purchase_date: Date.today,
+          quantity: 1,
+          total_price: 50
+        }
+      }
+    end
+    assert_response :created
+  end
+
+  test "should get count" do
+    get count_api_v1_purchases_url(granularity: 'day')
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert body.values.first.to_i >= 1
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,4 @@
+one:
+  name: Electronics
+  description: Tech stuff
+  administrator: admin_user

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,7 @@
+one:
+  name: Laptop
+  price: 1000.0
+  stock: 5
+  description: Basic laptop
+  administrator: admin_user
+  category: one

--- a/test/fixtures/purchases.yml
+++ b/test/fixtures/purchases.yml
@@ -1,0 +1,6 @@
+one:
+  product: one
+  customer: customer_user
+  purchase_date: 2024-01-01
+  quantity: 2
+  total_price: 2000.0

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,8 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+admin_user:
+  email: admin@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  admin: true
+customer_user:
+  email: customer@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  admin: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
+    include Devise::Test::IntegrationHelpers
     # Add more helper methods to be used by all tests here...
   end
 end


### PR DESCRIPTION
## Summary
- add JWT secret lookup fix
- enable Devise helpers in tests
- add fixtures for users, categories, products and purchases
- create tests for auth, products and purchases controllers

## Testing
- `bundle exec rails test test/controllers/api/v1/auth_controller_test.rb -v` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68744c8db7bc832e9985352fd194290b