### PR TITLE
Add AI summary endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,4 @@ end
 
 gem 'devise'
 gem 'devise-jwt'
+gem 'openai'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-musl)
       racc (~> 1.4)
+    openai (0.13.0)
+      connection_pool
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -300,6 +302,7 @@ DEPENDENCIES
   devise
   devise-jwt
   faker
+  openai
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)

--- a/app/controllers/api/v1/ai_controller.rb
+++ b/app/controllers/api/v1/ai_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::AiController < Api::V1::BaseController
+  before_action :authenticate_user!
+
+  def summary
+    result = AiClient.new.purchases_summary(current_user)
+    render json: { summary: result }
+  end
+end

--- a/app/services/ai_client.rb
+++ b/app/services/ai_client.rb
@@ -1,0 +1,21 @@
+class AiClient
+  def initialize
+    @client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
+  end
+
+  def purchases_summary(user)
+    purchases = user.purchases.includes(:product).order(purchase_date: :desc).limit(5)
+    list = purchases.map do |p|
+      "- #{p.product.name} x#{p.quantity} $#{p.total_price}"
+    end.join("\n")
+
+    prompt = "Resume las ultimas compras del usuario:\n" + list
+
+    response = @client.chat(parameters: {
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    })
+
+    response.dig('choices', 0, 'message', 'content')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post 'auth/login', to: 'auth#login'
       get 'token_info', to: 'tokens#show'
+      post 'ai/summary', to: 'ai#summary'
       get 'products/top_revenue', to: 'products#top_revenue'
       resources :products
       resources :categories, only: [:index, :create, :update]

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,27 @@
           "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNzUwMTI2MDQ0LCJleHAiOjE3NTAyOTg4NDQsImp0aSI6ImRhNGIwY2NjLTM3NTktNGYzYi1iNTRiLTkxM2QxZTZjZTgyNiJ9.C8v3Snp21rihsRQzhTg3f98VzKom-zl-8Ys0zbbhtHE"
         }
       }
+    },
+    {
+      "name": "resumir_compras",
+      "description": "Devuelve un resumen de las compras del usuario autenticado usando IA",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": { "type": "string" }
+        }
+      },
+      "endpoint": {
+        "url": "http://localhost:3000/api/v1/ai/summary",
+        "method": "POST",
+        "headers": {
+          "Authorization": "Bearer ..."
+        }
+      }
     }
   ]
 }

--- a/test/controllers/api/v1/ai_controller_test.rb
+++ b/test/controllers/api/v1/ai_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Api::V1::AiControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:customer_user)
+    sign_in @user
+  end
+
+  test "should get summary" do
+    OpenAI::Client.any_instance.stub(:chat, {"choices" => [{"message" => {"content" => "Resumen"}}]}) do
+      post api_v1_ai_summary_url
+    end
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal "Resumen", body["summary"]
+  end
+end


### PR DESCRIPTION
## Summary
- integrate `openai` gem
- create `AiClient` service to query OpenAI
- add `Api::V1::AiController` with `summary` action
- route `/api/v1/ai/summary`
- expose plugin `resumir_compras` in `manifest.json`
- test AI summary endpoint

## Testing
- `bundle install`
- `bin/rails test` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_e_687478bfead0832e8503a0a79db76100